### PR TITLE
同じ音素を連続して含む入力を与えた場合、出力アラインメントファイルで1つの音素にまとめて出力しないようにする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/
+pydomino.egg-info/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydomino"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = []
 requires-python = ">= 3.8"
 

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,9 @@ class CMakeBuild(build_ext):
 
             # Multi-config generators have a different way to specify configs
             if not single_config:
-                cmake_args += [f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{cfg.upper()}={extdir}"]
+                cmake_args += [
+                    f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{cfg.upper()}={extdir}"
+                ]
                 build_args += ["--config", cfg]
 
         if sys.platform.startswith("darwin"):
@@ -96,8 +98,12 @@ class CMakeBuild(build_ext):
         if not build_temp.exists():
             build_temp.mkdir(parents=True)
 
-        subprocess.run(["cmake", ext.sourcedir, *cmake_args], cwd=build_temp, check=True)
-        subprocess.run(["cmake", "--build", ".", *build_args], cwd=build_temp, check=True)
+        subprocess.run(
+            ["cmake", ext.sourcedir, *cmake_args], cwd=build_temp, check=True
+        )
+        subprocess.run(
+            ["cmake", "--build", ".", *build_args], cwd=build_temp, check=True
+        )
         subprocess.run(["cmake", "--install", "."], cwd=build_temp, check=True)
 
 
@@ -105,7 +111,7 @@ class CMakeBuild(build_ext):
 # logic and declaration, and simpler if you include description/version in a file.
 setup(
     name="pydomino_cpp",
-    version="1.1.0",
+    version="1.2.0",
     url="https://github.com/DwangoMediaVillage/pydomino",
     author="DWANGO Co., Ltd.",
     author_email="shun_ueda@dwango.co.jp",

--- a/src/phoneme_transition.cpp
+++ b/src/phoneme_transition.cpp
@@ -25,7 +25,6 @@ PhonemeTransitionTokenizer::PhonemeTransitionTokenizer() {
   );
 
   std::string line;
-  id_to_token_map.reserve(556);  // 音素遷移の総数
   while (std::getline(text, line)) {
     std::vector<std::string> phonemes;
     std::stringstream ss(line);

--- a/src/phoneme_transition.cpp
+++ b/src/phoneme_transition.cpp
@@ -143,7 +143,7 @@ std::vector<int> PhonemeTransitionTokenizer::read_phonemes(std::istream &ss) {
     }
     insert_pause_both_ends_if_not_exists(phonemes);
     unvoice_i_and_u(phonemes);
-    unique_consecutive(phonemes);
+    // unique_consecutive(phonemes);
 
     for (int i = 1; i < phonemes.size(); ++i) {
       PhonemeTransition transition = PhonemeTransition{phonemes[i - 1], phonemes[i]};

--- a/src/phoneme_transitions.txt
+++ b/src/phoneme_transitions.txt
@@ -482,6 +482,7 @@ N e
 N o
 N cl
 N pau
+N N
 cl ry
 cl r
 cl my


### PR DESCRIPTION
pydomino を version 1.2.0 にアップデートをします。

長母音間の遷移タイミングの予測が出来るようになりました。全体の音素アラインメントの精度は1.1.0から変わっていません。